### PR TITLE
Fix release pipeline, temporal versioning, workflow hygiene

### DIFF
--- a/.github/workflows/actions-prune.yml
+++ b/.github/workflows/actions-prune.yml
@@ -12,7 +12,7 @@ on:
         description: "Number of recent items to keep per workflow/key"
         type: string
         required: false
-        default: '1'
+        default: '3'
       stale-minutes:
         description: "Grace window in minutes"
         type: string
@@ -23,14 +23,11 @@ on:
         type: string
         required: false
         default: 'false'
-  workflow_call:
-
-
 
 jobs:
   cleanup-actions:
     uses: Mimis-Gildi/fluffle/.github/workflows/actions-prune.yml@main
     with:
       dry-run: ${{ inputs.dry-run || 'false' }}
-      keep-last: ${{ inputs.keep-last || '1' }}
-      stale-minutes: ${{ inputs.stale-minutes || '3' }}
+      keep-last: ${{ inputs.keep-last || '0' }}
+      stale-minutes: ${{ inputs.stale-minutes || '0' }}

--- a/.github/workflows/actions-prune.yml
+++ b/.github/workflows/actions-prune.yml
@@ -3,6 +3,9 @@ run-name: "Clean Actions ${{ github.repository }} by ${{ github.actor }} with ${
 
 on:
   push:
+    branches-ignore:
+      - 'renovate/**'
+      - 'dependabot/**'
   workflow_dispatch:
     inputs:
       keep-last:

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -41,7 +41,9 @@ jobs:
   update-resume-links:
     needs: increment
     if: ${{ needs.increment.outputs.new != '' }}
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - lock
     timeout-minutes: 3
     steps:
 

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -87,7 +87,6 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git fetch && git pull
           git add -A
           git commit -m "Update resume version references to v${{ needs.increment.outputs.new }} [skip up]"

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -27,6 +27,10 @@ defaults:
   run:
     shell: zsh -l {0}
 
+concurrency:
+  group: incrementer-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   increment:
     if: ${{ !(github.event_name == 'push' && github.event.created) }}
@@ -44,6 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
         with:
+          ref: ${{ github.head_ref || github.ref }}
           fetch-depth: 0
           persist-credentials: 'true'
 

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -95,7 +95,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git fetch && git pull
           git add -A
           git commit -m "Update resume version references to v${{ needs.increment.outputs.new }} [skip up]"

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -41,9 +41,7 @@ jobs:
   update-resume-links:
     needs: increment
     if: ${{ needs.increment.outputs.new != '' }}
-    runs-on:
-      - self-hosted
-      - lock
+    runs-on: self-hosted
     timeout-minutes: 3
     steps:
 

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - '[0-9]+-**'
   pull_request:
+    branches-ignore:
+      - 'renovate/**'
+      - 'dependabot/**'
     types:
       - synchronize
       - opened

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -95,7 +95,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
           git fetch && git pull
           git add -A
           git commit -m "Update resume version references to v${{ needs.increment.outputs.new }} [skip up]"

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -40,12 +40,11 @@ jobs:
     uses: Mimis-Gildi/fluffle/.github/workflows/incrementer.yml@main
     secrets: inherit
 
-
   update-resume-links:
     needs: increment
     if: ${{ needs.increment.outputs.new != '' }}
     runs-on: self-hosted
-    timeout-minutes: 3
+    timeout-minutes: 4
     steps:
 
       - name: Checkout
@@ -57,6 +56,7 @@ jobs:
 
       - name: Check for resume label
         id: label-check
+        timeout-minutes: 1
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -73,6 +73,7 @@ jobs:
 
       - name: Update resume version references
         if: ${{ steps.label-check.outputs.update == 'true' }}
+        timeout-minutes: 1
         uses: ./.github/actions/update-version-references
         with:
           superseded-version: v${{ needs.increment.outputs.old }}
@@ -87,6 +88,7 @@ jobs:
             ]
 
       - name: Commit and push
+        timeout-minutes: 2
         if: ${{ steps.label-check.outputs.update == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -63,7 +63,7 @@ jobs:
           (( $+GITHUB_TOKEN )) && printf 'GITHUB_TOKEN is set!\n' || printf 'GITHUB_TOKEN is NOT set!\n'
           (( $+GH_TOKEN )) && printf 'GH_TOKEN is set!\n' || printf 'GH_TOKEN is NOT set!\n'
 
-          LABELS=$(gh pr list --json labels --jq '.[0].labels[].name' 2>/dev/null)
+          LABELS=$(gh pr view --json labels --jq '.labels[].name' 2>/dev/null)
           printf '::trace title=Label Check::Labels found: %s\n' "$LABELS"
           HAS_LABEL=$(echo "$LABELS" | grep -c '^resume$')
           if (( HAS_LABEL == 1 )); then

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -14,6 +14,7 @@ on:
       - '[0-9]+-**'
   pull_request:
     types:
+      - synchronize
       - opened
       - reopened
   workflow_dispatch:
@@ -51,15 +52,15 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          (( $+GITHUB_TOKEN )) && echo "GITHUB_TOKEN is set!" || echo "GITHUB_TOKEN is NOT set!" 
-          (( $+GH_TOKEN )) && echo "GH_TOKEN is set!" || echo "GH_TOKEN is NOT set!"
-          
+          (( $+GITHUB_TOKEN )) && printf 'GITHUB_TOKEN is set!\n' || printf 'GITHUB_TOKEN is NOT set!\n'
+          (( $+GH_TOKEN )) && printf 'GH_TOKEN is set!\n' || printf 'GH_TOKEN is NOT set!\n'
+
           HAS_LABEL=$(gh pr list --json labels --jq '.[0].labels[].name' 2>/dev/null | grep -c '^resume$')
           if (( HAS_LABEL == 1 )); then
-            echo "::notice::This is a resume update PR."
+            printf '::notice::This is a resume update PR.\n'
             echo "update=true" >> $GITHUB_OUTPUT
           else
-            echo "::notice::NOT a resume update PR."
+            printf '::notice::NOT a resume update PR.\n'
           fi
 
       - name: Update resume version references
@@ -82,8 +83,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          (( $+GITHUB_TOKEN )) && echo "GITHUB_TOKEN is set!" || echo "GITHUB_TOKEN is NOT set!" 
-          (( $+GH_TOKEN )) && echo "GH_TOKEN is set!" || echo "GH_TOKEN is NOT set!"
+          (( $+GITHUB_TOKEN )) && printf 'GITHUB_TOKEN is set!\n' || printf 'GITHUB_TOKEN is NOT set!\n'
+          (( $+GH_TOKEN )) && printf 'GH_TOKEN is set!\n' || printf 'GH_TOKEN is NOT set!\n'
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -63,7 +63,9 @@ jobs:
           (( $+GITHUB_TOKEN )) && printf 'GITHUB_TOKEN is set!\n' || printf 'GITHUB_TOKEN is NOT set!\n'
           (( $+GH_TOKEN )) && printf 'GH_TOKEN is set!\n' || printf 'GH_TOKEN is NOT set!\n'
 
-          HAS_LABEL=$(gh pr list --json labels --jq '.[0].labels[].name' 2>/dev/null | grep -c '^resume$')
+          LABELS=$(gh pr list --json labels --jq '.[0].labels[].name' 2>/dev/null)
+          printf '::trace title=Label Check::Labels found: %s\n' "$LABELS"
+          HAS_LABEL=$(echo "$LABELS" | grep -c '^resume$')
           if (( HAS_LABEL == 1 )); then
             printf '::notice::This is a resume update PR.\n'
             echo "update=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -93,6 +93,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git fetch && git pull
           git add -A
           git commit -m "Update resume version references to v${{ needs.increment.outputs.new }} [skip up]"

--- a/.github/workflows/incrementer.yml
+++ b/.github/workflows/incrementer.yml
@@ -95,7 +95,10 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          # This is a very specific local work-around for some agents that run on alternative git implementation.
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
           git fetch && git pull
           git add -A
           git commit -m "Update resume version references to v${{ needs.increment.outputs.new }} [skip up]"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,6 +3,9 @@ run-name: "Labeled Pull Request examining content on ${{ github.actor }} with ${
 
 on:
   pull_request:
+    branches-ignore:
+      - 'renovate/**'
+      - 'dependabot/**'
     types:
       - opened
       - synchronize

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -9,8 +9,6 @@ on:
   workflow_dispatch:
   pull_request:
     types:
-      - opened
-      - reopened
       - synchronize
   schedule:
     - cron: '11 11 * * *'
@@ -39,7 +37,6 @@ jobs:
         uses: actions/checkout@v6.0.2
         timeout-minutes: 3
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Run Qodana Scan

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -4,10 +4,12 @@ run-name: "Qodana scan on ${{ github.repository }} by ${{ github.actor }} with $
 on:
   push:
     branches-ignore:
-      - main
       - '*'
   workflow_dispatch:
   pull_request:
+    branches-ignore:
+      - 'renovate/**'
+      - 'dependabot/**'
     types:
       - synchronize
   schedule:

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches-ignore:
       - main
+      - '*'
   workflow_dispatch:
   pull_request:
     types:

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -41,11 +41,17 @@ jobs:
           ref: main
 
       - name: Update resumeVersion
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(grep '^version=' gradle.properties | cut -d= -f2)
           sed -i "s/^resumeVersion=.*/resumeVersion=v${VERSION}/" gradle.properties
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          # This is a very specific local work-around for some agents that run on alternative git implementation.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          
           git add gradle.properties
           git diff --cached --quiet || git commit -m "Update resumeVersion to v${VERSION} [skip up]"
           git pull --rebase

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -15,6 +15,10 @@ on:
         default: false
         description: 'Build and attach resume PDF'
 
+defaults:
+  run:
+    shell: zsh -l {0}
+
 jobs:
   release:
     uses: Mimis-Gildi/fluffle/.github/workflows/releaser.yml@main

--- a/.github/workflows/runner-introspect.yml
+++ b/.github/workflows/runner-introspect.yml
@@ -3,6 +3,9 @@ run-name: "Fly the Runner on ${{ github.repository }} by ${{ github.actor }} wit
 
 on:
   push:
+    branches-ignore:
+      - 'renovate/**'
+      - 'dependabot/**'
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,29 @@
 # CHANGELOG.md
 
-## [7.0.3] — Fix release pipeline and clean up workflow slop
+## [7.10.0] — Fix release pipeline, temporal versioning, workflow hygiene
 
 ### Release Pipeline
 
 - Fix `GH_TOKEN` authentication for `gh` CLI — `GITHUB_TOKEN` is not a shell env var on self-hosted runners
-- Fix resume link auto-update — reusable workflow outputs weren't propagated, label check needed API not event context
+- Fix resume link auto-update — reusable workflow outputs weren't propagated, label check via API not event context
 - Add artifact existence check before `gh release upload`
 - Add `git fetch && git pull` before push steps to prevent stale local copy rejections
+- Add `remote set-url` workaround for agents with alternative git implementations
 
-### Workflow Cleanup
+### Temporal Versioning
 
-- Remove dead `remote set-url` overrides — checkout persisted credentials handle auth
-- Remove unnecessary `ref:`, `token:`, `persist-credentials:` overrides from checkout steps
-- Qodana: remove `ref:` override, restrict to `synchronize` events, bump linter to 2025.3
+- Add `synchronize` to PR events — minor bump on every push to PR branch
+- Add `PR_SKIP` — push events defer to `pull_request synchronize` when PR exists
+- Concurrency groups keyed on `github.head_ref || github.ref` with cancel-in-progress
+- Reusable workflow outputs propagated via `workflow_call: outputs:`
+
+### Workflow Hygiene
+
+- Exclude `renovate/**` and `dependabot/**` from all workflow triggers across both repos
+- Enforce `zsh -l` shell default on all workflows with run steps
+- Remove unnecessary `ref:`, `token:`, `persist-credentials:` overrides from read-only checkouts
+- Restore `ref:` on checkouts that push — not slop when the workflow writes to the branch
+- Qodana: restrict to `synchronize` events, bump linter to 2025.3
 
 ### Resume
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # CHANGELOG.md
 
+## [7.0.3] — Fix release pipeline and clean up workflow slop
+
+### Release Pipeline
+
+- Fix `GH_TOKEN` authentication for `gh` CLI — `GITHUB_TOKEN` is not a shell env var on self-hosted runners
+- Fix resume link auto-update — reusable workflow outputs weren't propagated, label check needed API not event context
+- Add artifact existence check before `gh release upload`
+- Add `git fetch && git pull` before push steps to prevent stale local copy rejections
+
+### Workflow Cleanup
+
+- Remove dead `remote set-url` overrides — checkout persisted credentials handle auth
+- Remove unnecessary `ref:`, `token:`, `persist-credentials:` overrides from checkout steps
+- Qodana: remove `ref:` override, restrict to `synchronize` events, bump linter to 2025.3
+
+### Resume
+
+- Fix `J&J` ampersand XML parse warning in PDF generation
+- Tighten header/footer height in theme
+
 ## [4.5.0] — Resume refresh and CI/CD overhaul
 
 Applied feedback from 11 reviewers. Rebuilt resume structure. Externalized CI/CD to fluffle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG.md
 
-## [7.13.0] — Fix release pipeline, temporal versioning, workflow hygiene
+## [7.15.0] — Fix release pipeline, temporal versioning, workflow hygiene
 
 ### Release Pipeline
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG.md
 
-## [7.10.0] — Fix release pipeline, temporal versioning, workflow hygiene
+## [7.13.0] — Fix release pipeline, temporal versioning, workflow hygiene
 
 ### Release Pipeline
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Mímis Gildi: Rdd13r’s Living Digital Garden
 Vadim Kuhay <12781006+rdd13r@users.noreply.github.com>
-v7.0.2, Saturday April 18th 2026
+v7.0.3, Saturday April 18th 2026
 :description: Living and evolving publication repository by `rdd13r`.
 :icons: font
 :!toc:
@@ -47,7 +47,7 @@ image:https://img.shields.io/badge/Subscribe-LinkedIn-0A66C2?style=for-the-badge
 == Contact
 
 * Email: mailto:vadim@asei.systems[vadim@asei.systems] | mailto:rIdd13r@pm.me[rIdd13r@pm.me] <- crypted
-* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.2/VadimKuhay-Resume.pdf[Résumé]_
+* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.3/VadimKuhay-Resume.pdf[Résumé]_
 
 _Still, the best way to get to know me is to make software *with* me_ +
 {nbsp} +

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Mímis Gildi: Rdd13r’s Living Digital Garden
 Vadim Kuhay <12781006+rdd13r@users.noreply.github.com>
-v6.0.19, Saturday April 18th 2026
+v7.0.2, Saturday April 18th 2026
 :description: Living and evolving publication repository by `rdd13r`.
 :icons: font
 :!toc:
@@ -47,7 +47,7 @@ image:https://img.shields.io/badge/Subscribe-LinkedIn-0A66C2?style=for-the-badge
 == Contact
 
 * Email: mailto:vadim@asei.systems[vadim@asei.systems] | mailto:rIdd13r@pm.me[rIdd13r@pm.me] <- crypted
-* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v6.0.19/VadimKuhay-Resume.pdf[Résumé]_
+* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.2/VadimKuhay-Resume.pdf[Résumé]_
 
 _Still, the best way to get to know me is to make software *with* me_ +
 {nbsp} +

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Mímis Gildi: Rdd13r’s Living Digital Garden
 Vadim Kuhay <12781006+rdd13r@users.noreply.github.com>
-v7.5.0, Sunday April 19th 2026
+v7.6.0, Sunday April 19th 2026
 :description: Living and evolving publication repository by `rdd13r`.
 :icons: font
 :!toc:
@@ -47,7 +47,7 @@ image:https://img.shields.io/badge/Subscribe-LinkedIn-0A66C2?style=for-the-badge
 == Contact
 
 * Email: mailto:vadim@asei.systems[vadim@asei.systems] | mailto:rIdd13r@pm.me[rIdd13r@pm.me] <- crypted
-* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.5.0/VadimKuhay-Resume.pdf[Résumé]_
+* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.6.0/VadimKuhay-Resume.pdf[Résumé]_
 
 _Still, the best way to get to know me is to make software *with* me_ +
 {nbsp} +

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Mímis Gildi: Rdd13r’s Living Digital Garden
 Vadim Kuhay <12781006+rdd13r@users.noreply.github.com>
-v7.2.0, Sunday April 19th 2026
+v7.3.0, Sunday April 19th 2026
 :description: Living and evolving publication repository by `rdd13r`.
 :icons: font
 :!toc:
@@ -47,7 +47,7 @@ image:https://img.shields.io/badge/Subscribe-LinkedIn-0A66C2?style=for-the-badge
 == Contact
 
 * Email: mailto:vadim@asei.systems[vadim@asei.systems] | mailto:rIdd13r@pm.me[rIdd13r@pm.me] <- crypted
-* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.2.0/VadimKuhay-Resume.pdf[Résumé]_
+* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.3.0/VadimKuhay-Resume.pdf[Résumé]_
 
 _Still, the best way to get to know me is to make software *with* me_ +
 {nbsp} +

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Mímis Gildi: Rdd13r’s Living Digital Garden
 Vadim Kuhay <12781006+rdd13r@users.noreply.github.com>
-v7.0.3, Saturday April 18th 2026
+v7.2.0, Sunday April 19th 2026
 :description: Living and evolving publication repository by `rdd13r`.
 :icons: font
 :!toc:
@@ -47,7 +47,7 @@ image:https://img.shields.io/badge/Subscribe-LinkedIn-0A66C2?style=for-the-badge
 == Contact
 
 * Email: mailto:vadim@asei.systems[vadim@asei.systems] | mailto:rIdd13r@pm.me[rIdd13r@pm.me] <- crypted
-* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.3/VadimKuhay-Resume.pdf[Résumé]_
+* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.2.0/VadimKuhay-Resume.pdf[Résumé]_
 
 _Still, the best way to get to know me is to make software *with* me_ +
 {nbsp} +

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Mímis Gildi: Rdd13r’s Living Digital Garden
 Vadim Kuhay <12781006+rdd13r@users.noreply.github.com>
-v7.6.0, Sunday April 19th 2026
+v7.15.0, Sunday April 19th 2026
 :description: Living and evolving publication repository by `rdd13r`.
 :icons: font
 :!toc:
@@ -47,7 +47,7 @@ image:https://img.shields.io/badge/Subscribe-LinkedIn-0A66C2?style=for-the-badge
 == Contact
 
 * Email: mailto:vadim@asei.systems[vadim@asei.systems] | mailto:rIdd13r@pm.me[rIdd13r@pm.me] <- crypted
-* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.6.0/VadimKuhay-Resume.pdf[Résumé]_
+* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.15.0/VadimKuhay-Resume.pdf[Résumé]_
 
 _Still, the best way to get to know me is to make software *with* me_ +
 {nbsp} +

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Mímis Gildi: Rdd13r’s Living Digital Garden
 Vadim Kuhay <12781006+rdd13r@users.noreply.github.com>
-v7.3.0, Sunday April 19th 2026
+v7.5.0, Sunday April 19th 2026
 :description: Living and evolving publication repository by `rdd13r`.
 :icons: font
 :!toc:
@@ -47,7 +47,7 @@ image:https://img.shields.io/badge/Subscribe-LinkedIn-0A66C2?style=for-the-badge
 == Contact
 
 * Email: mailto:vadim@asei.systems[vadim@asei.systems] | mailto:rIdd13r@pm.me[rIdd13r@pm.me] <- crypted
-* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.3.0/VadimKuhay-Resume.pdf[Résumé]_
+* Signal / Discord / Text: +1 (919) 717-1387 ([bot]) / _https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.5.0/VadimKuhay-Resume.pdf[Résumé]_
 
 _Still, the best way to get to know me is to make software *with* me_ +
 {nbsp} +

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.7.0
+version=7.8.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.5.0
+version=7.6.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.0.3
+version=7.1.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.2.0
+version=7.3.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.9.0
+version=7.10.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.1.0
+version=7.2.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.6.0
+version=7.7.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.3.0
+version=7.4.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.4.0
+version=7.5.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.0.0
+version=7.0.1
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.0.2
+version=7.0.3
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.14.0
+version=7.15.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.13.0
+version=7.14.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=6.0.19
+version=7.0.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.11.0
+version=7.12.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.0.1
+version=7.0.2
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.8.0
+version=7.9.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.12.0
+version=7.13.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ useJavaVersion=21
 useReleaseDependenciesOnly=true
 
 group=me.riddle.the
-version=7.10.0
+version=7.11.0
 resumeDate=2026-04-13
 resumeVersion=v4.5.0
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,15 @@
 [versions]
 asciidoctorJvm = "4.0.5"
-#asciidoctorDiagram = "2.3.2"
-benManes = "0.53.0"
-dokka = "2.2.0"
 
 logback = "1.5.32"
 kotlinLogging = "8.0.01"
 slf4j = "2.0.17"
 
 [plugins]
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 asciidoctor-jvm-pdf = { id = "org.asciidoctor.jvm.pdf", version.ref = "asciidoctorJvm" }
 asciidoctor-jvm-epub = { id = "org.asciidoctor.jvm.epub", version.ref = "asciidoctorJvm" }
 asciidoctor-jvm-gems = { id = "org.asciidoctor.jvm.gems", version.ref = "asciidoctorJvm" }
 asciidoctor-jvm-convert = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctorJvm" }
-ben-manes = { id = "com.github.ben-manes.versions", version.ref = "benManes" }
 
 [libraries]
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: "1.0"
-linter: jetbrains/qodana-jvm-community:2025.2
+linter: jetbrains/qodana-jvm-community:2025.3
 profile:
   name: qodana.recommended
 include:

--- a/resume/themes/engineering-resume-theme.yml
+++ b/resume/themes/engineering-resume-theme.yml
@@ -6,7 +6,7 @@ base:
   font_style: normal
 
 header:
-  height: 0.6in
+  height: 0.55in
   line-height: 1
   recto:
     center:
@@ -17,7 +17,7 @@ header:
     right:
       content: 'https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v{revnumber}[v{revnumber}]'
 footer:
-  height: 0.6in
+  height: 0.55in
   line-height: 1
   recto:
     right:

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -122,7 +122,7 @@ words_per_minute            : 300
 enable_copy_code_button     : true
 compress_html               : true
 
-copyright                   : "© Vadim Kuhay; 2022–2026; v7.2.0"
+copyright                   : "© Vadim Kuhay; 2022–2026; v7.3.0"
 copyright_url               : "https://mimis-gildi.github.io/riddle-me-this"
 
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -122,7 +122,7 @@ words_per_minute            : 300
 enable_copy_code_button     : true
 compress_html               : true
 
-copyright                   : "© Vadim Kuhay; 2022–2026; v7.6.0"
+copyright                   : "© Vadim Kuhay; 2022–2026; v7.15.0"
 copyright_url               : "https://mimis-gildi.github.io/riddle-me-this"
 
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -122,7 +122,7 @@ words_per_minute            : 300
 enable_copy_code_button     : true
 compress_html               : true
 
-copyright                   : "© Vadim Kuhay; 2022–2026; v7.5.0"
+copyright                   : "© Vadim Kuhay; 2022–2026; v7.6.0"
 copyright_url               : "https://mimis-gildi.github.io/riddle-me-this"
 
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -122,7 +122,7 @@ words_per_minute            : 300
 enable_copy_code_button     : true
 compress_html               : true
 
-copyright                   : "© Vadim Kuhay; 2022–2026; v7.3.0"
+copyright                   : "© Vadim Kuhay; 2022–2026; v7.5.0"
 copyright_url               : "https://mimis-gildi.github.io/riddle-me-this"
 
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -122,7 +122,7 @@ words_per_minute            : 300
 enable_copy_code_button     : true
 compress_html               : true
 
-copyright                   : "© Vadim Kuhay; 2022–2026; v6.0.19"
+copyright                   : "© Vadim Kuhay; 2022–2026; v7.0.2"
 copyright_url               : "https://mimis-gildi.github.io/riddle-me-this"
 
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -122,7 +122,7 @@ words_per_minute            : 300
 enable_copy_code_button     : true
 compress_html               : true
 
-copyright                   : "© Vadim Kuhay; 2022–2026; v7.0.2"
+copyright                   : "© Vadim Kuhay; 2022–2026; v7.0.3"
 copyright_url               : "https://mimis-gildi.github.io/riddle-me-this"
 
 

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -122,7 +122,7 @@ words_per_minute            : 300
 enable_copy_code_button     : true
 compress_html               : true
 
-copyright                   : "© Vadim Kuhay; 2022–2026; v7.0.3"
+copyright                   : "© Vadim Kuhay; 2022–2026; v7.2.0"
 copyright_url               : "https://mimis-gildi.github.io/riddle-me-this"
 
 

--- a/site/_pages/maintainer.adoc
+++ b/site/_pages/maintainer.adoc
@@ -7,8 +7,8 @@ header:
 :page-layout: single
 :page-permalink: /maintainer/
 :page-author_profile: true
-:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.3.0[v7.3.0,window=_blank]
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.3.0/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
+:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.5.0[v7.5.0,window=_blank]
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.5.0/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
 :profile-li: https://www.linkedin.com/in/rdd13r[LinkedIn Profile,window=_blank]
 :profile-gh: https://github.com/rdd13r[GitHub Profile,window=_blank]
 :publications-mm: https://medium.com/@rdd13r[Medium Articles,window=_blank]

--- a/site/_pages/maintainer.adoc
+++ b/site/_pages/maintainer.adoc
@@ -7,8 +7,8 @@ header:
 :page-layout: single
 :page-permalink: /maintainer/
 :page-author_profile: true
-:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.0.3[v7.0.3,window=_blank]
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.3/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
+:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.2.0[v7.2.0,window=_blank]
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.2.0/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
 :profile-li: https://www.linkedin.com/in/rdd13r[LinkedIn Profile,window=_blank]
 :profile-gh: https://github.com/rdd13r[GitHub Profile,window=_blank]
 :publications-mm: https://medium.com/@rdd13r[Medium Articles,window=_blank]

--- a/site/_pages/maintainer.adoc
+++ b/site/_pages/maintainer.adoc
@@ -7,8 +7,8 @@ header:
 :page-layout: single
 :page-permalink: /maintainer/
 :page-author_profile: true
-:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.2.0[v7.2.0,window=_blank]
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.2.0/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
+:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.3.0[v7.3.0,window=_blank]
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.3.0/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
 :profile-li: https://www.linkedin.com/in/rdd13r[LinkedIn Profile,window=_blank]
 :profile-gh: https://github.com/rdd13r[GitHub Profile,window=_blank]
 :publications-mm: https://medium.com/@rdd13r[Medium Articles,window=_blank]

--- a/site/_pages/maintainer.adoc
+++ b/site/_pages/maintainer.adoc
@@ -7,8 +7,8 @@ header:
 :page-layout: single
 :page-permalink: /maintainer/
 :page-author_profile: true
-:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v6.0.19[v6.0.19,window=_blank]
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v6.0.19/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
+:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.0.2[v7.0.2,window=_blank]
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.2/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
 :profile-li: https://www.linkedin.com/in/rdd13r[LinkedIn Profile,window=_blank]
 :profile-gh: https://github.com/rdd13r[GitHub Profile,window=_blank]
 :publications-mm: https://medium.com/@rdd13r[Medium Articles,window=_blank]

--- a/site/_pages/maintainer.adoc
+++ b/site/_pages/maintainer.adoc
@@ -7,8 +7,8 @@ header:
 :page-layout: single
 :page-permalink: /maintainer/
 :page-author_profile: true
-:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.0.2[v7.0.2,window=_blank]
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.2/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
+:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.0.3[v7.0.3,window=_blank]
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.3/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
 :profile-li: https://www.linkedin.com/in/rdd13r[LinkedIn Profile,window=_blank]
 :profile-gh: https://github.com/rdd13r[GitHub Profile,window=_blank]
 :publications-mm: https://medium.com/@rdd13r[Medium Articles,window=_blank]

--- a/site/_pages/maintainer.adoc
+++ b/site/_pages/maintainer.adoc
@@ -7,8 +7,8 @@ header:
 :page-layout: single
 :page-permalink: /maintainer/
 :page-author_profile: true
-:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.6.0[v7.6.0,window=_blank]
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.6.0/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
+:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.15.0[v7.15.0,window=_blank]
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.15.0/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
 :profile-li: https://www.linkedin.com/in/rdd13r[LinkedIn Profile,window=_blank]
 :profile-gh: https://github.com/rdd13r[GitHub Profile,window=_blank]
 :publications-mm: https://medium.com/@rdd13r[Medium Articles,window=_blank]

--- a/site/_pages/maintainer.adoc
+++ b/site/_pages/maintainer.adoc
@@ -7,8 +7,8 @@ header:
 :page-layout: single
 :page-permalink: /maintainer/
 :page-author_profile: true
-:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.5.0[v7.5.0,window=_blank]
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.5.0/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
+:release: https://github.com/Mimis-Gildi/riddle-me-this/releases/tag/v7.6.0[v7.6.0,window=_blank]
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.6.0/VadimKuhay-Resume.pdf[Vadim Kuhay Résumé,window=_blank]
 :profile-li: https://www.linkedin.com/in/rdd13r[LinkedIn Profile,window=_blank]
 :profile-gh: https://github.com/rdd13r[GitHub Profile,window=_blank]
 :publications-mm: https://medium.com/@rdd13r[Medium Articles,window=_blank]

--- a/site/index.adoc
+++ b/site/index.adoc
@@ -13,7 +13,7 @@ sidebar:
 = Vadim Kuhay
 :icons: font
 :imagesdir: ./assets/images
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.3.0/VadimKuhay-Resume.pdf
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.5.0/VadimKuhay-Resume.pdf
 :mailto-aseix: mailto:vadim@asei.systems?subject=About%20your%20business%2C%20M%C3%ADmis%20Gildi%20&body=Hello%20Vadim%2C%0A%0A%20%20I%20found%20your%20business%20email%20on%20your%20blog%20site[vadim@asei.systems]
 :mailto-rIdd13r: mailto:rIdd13r@pm.me?subject=Hello%20Riddler%20-%20Let's%20compete%3F[rIdd13r@pm.me]
 :who-i-write-for: link:/riddle-me-this/about/#who-i-write-for[Who I write for?,window=_blank]

--- a/site/index.adoc
+++ b/site/index.adoc
@@ -13,7 +13,7 @@ sidebar:
 = Vadim Kuhay
 :icons: font
 :imagesdir: ./assets/images
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v6.0.19/VadimKuhay-Resume.pdf
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.2/VadimKuhay-Resume.pdf
 :mailto-aseix: mailto:vadim@asei.systems?subject=About%20your%20business%2C%20M%C3%ADmis%20Gildi%20&body=Hello%20Vadim%2C%0A%0A%20%20I%20found%20your%20business%20email%20on%20your%20blog%20site[vadim@asei.systems]
 :mailto-rIdd13r: mailto:rIdd13r@pm.me?subject=Hello%20Riddler%20-%20Let's%20compete%3F[rIdd13r@pm.me]
 :who-i-write-for: link:/riddle-me-this/about/#who-i-write-for[Who I write for?,window=_blank]

--- a/site/index.adoc
+++ b/site/index.adoc
@@ -13,7 +13,7 @@ sidebar:
 = Vadim Kuhay
 :icons: font
 :imagesdir: ./assets/images
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.6.0/VadimKuhay-Resume.pdf
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.15.0/VadimKuhay-Resume.pdf
 :mailto-aseix: mailto:vadim@asei.systems?subject=About%20your%20business%2C%20M%C3%ADmis%20Gildi%20&body=Hello%20Vadim%2C%0A%0A%20%20I%20found%20your%20business%20email%20on%20your%20blog%20site[vadim@asei.systems]
 :mailto-rIdd13r: mailto:rIdd13r@pm.me?subject=Hello%20Riddler%20-%20Let's%20compete%3F[rIdd13r@pm.me]
 :who-i-write-for: link:/riddle-me-this/about/#who-i-write-for[Who I write for?,window=_blank]

--- a/site/index.adoc
+++ b/site/index.adoc
@@ -13,7 +13,7 @@ sidebar:
 = Vadim Kuhay
 :icons: font
 :imagesdir: ./assets/images
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.2/VadimKuhay-Resume.pdf
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.3/VadimKuhay-Resume.pdf
 :mailto-aseix: mailto:vadim@asei.systems?subject=About%20your%20business%2C%20M%C3%ADmis%20Gildi%20&body=Hello%20Vadim%2C%0A%0A%20%20I%20found%20your%20business%20email%20on%20your%20blog%20site[vadim@asei.systems]
 :mailto-rIdd13r: mailto:rIdd13r@pm.me?subject=Hello%20Riddler%20-%20Let's%20compete%3F[rIdd13r@pm.me]
 :who-i-write-for: link:/riddle-me-this/about/#who-i-write-for[Who I write for?,window=_blank]

--- a/site/index.adoc
+++ b/site/index.adoc
@@ -13,7 +13,7 @@ sidebar:
 = Vadim Kuhay
 :icons: font
 :imagesdir: ./assets/images
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.2.0/VadimKuhay-Resume.pdf
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.3.0/VadimKuhay-Resume.pdf
 :mailto-aseix: mailto:vadim@asei.systems?subject=About%20your%20business%2C%20M%C3%ADmis%20Gildi%20&body=Hello%20Vadim%2C%0A%0A%20%20I%20found%20your%20business%20email%20on%20your%20blog%20site[vadim@asei.systems]
 :mailto-rIdd13r: mailto:rIdd13r@pm.me?subject=Hello%20Riddler%20-%20Let's%20compete%3F[rIdd13r@pm.me]
 :who-i-write-for: link:/riddle-me-this/about/#who-i-write-for[Who I write for?,window=_blank]

--- a/site/index.adoc
+++ b/site/index.adoc
@@ -13,7 +13,7 @@ sidebar:
 = Vadim Kuhay
 :icons: font
 :imagesdir: ./assets/images
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.0.3/VadimKuhay-Resume.pdf
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.2.0/VadimKuhay-Resume.pdf
 :mailto-aseix: mailto:vadim@asei.systems?subject=About%20your%20business%2C%20M%C3%ADmis%20Gildi%20&body=Hello%20Vadim%2C%0A%0A%20%20I%20found%20your%20business%20email%20on%20your%20blog%20site[vadim@asei.systems]
 :mailto-rIdd13r: mailto:rIdd13r@pm.me?subject=Hello%20Riddler%20-%20Let's%20compete%3F[rIdd13r@pm.me]
 :who-i-write-for: link:/riddle-me-this/about/#who-i-write-for[Who I write for?,window=_blank]

--- a/site/index.adoc
+++ b/site/index.adoc
@@ -13,7 +13,7 @@ sidebar:
 = Vadim Kuhay
 :icons: font
 :imagesdir: ./assets/images
-:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.5.0/VadimKuhay-Resume.pdf
+:resume: https://github.com/Mimis-Gildi/riddle-me-this/releases/download/v7.6.0/VadimKuhay-Resume.pdf
 :mailto-aseix: mailto:vadim@asei.systems?subject=About%20your%20business%2C%20M%C3%ADmis%20Gildi%20&body=Hello%20Vadim%2C%0A%0A%20%20I%20found%20your%20business%20email%20on%20your%20blog%20site[vadim@asei.systems]
 :mailto-rIdd13r: mailto:rIdd13r@pm.me?subject=Hello%20Riddler%20-%20Let's%20compete%3F[rIdd13r@pm.me]
 :who-i-write-for: link:/riddle-me-this/about/#who-i-write-for[Who I write for?,window=_blank]


### PR DESCRIPTION
## Why?

Release pipeline was broken -- `gh` CLI couldn't authenticate because `GITHUB_TOKEN` isn't a shell env var on self-hosted runners. Resume link auto-update never ran because reusable workflow outputs weren't propagated and label check grabbed the wrong PR. Version bumped on every push instead of deferring to PR events.

## What changed?

### Release Pipeline
- Fix `GH_TOKEN` authentication for `gh` CLI via step-level YAML env injection
- Fix resume link auto-update — propagate reusable workflow outputs via `workflow_call: outputs:`, check labels with `gh pr view` not `gh pr list`
- Add artifact existence check before `gh release upload`
- Add `git fetch && git pull` before push steps to prevent stale local copy rejections
- Add `remote set-url` workaround for agents with alternative git implementations

### Temporal Versioning
- Add `synchronize` to PR events — minor bump on every push to PR branch
- Add `PR_SKIP` — push events defer to `pull_request synchronize` when PR exists
- Concurrency groups keyed on `github.head_ref || github.ref` with cancel-in-progress

### Workflow Hygiene
- Exclude `renovate/**` and `dependabot/**` from all workflow triggers across both repos
- Enforce `zsh -l` shell default on all workflows with run steps
- Remove unnecessary `ref:`, `token:`, `persist-credentials:` overrides from read-only checkouts
- Restore `ref:` on checkouts that push

### Resume
- Fix `J&J` ampersand XML parse warning in PDF generation
- Tighten header/footer height in theme

## List all your tests that defined this feature:

- [x] `GH_TOKEN` diagnostic (`$+GITHUB_TOKEN` / `$+GH_TOKEN`) confirmed token state on self-hosted runners
- [x] Label check trace confirmed `gh pr view` reads correct PR labels
- [x] `PR_SKIP` trace confirmed push events defer when PR exists (PR Skip 1 on push, PR Skip 0 on pull_request)
- [x] Resume link update committed and pushed v7.15.0 references across 4 files
- [x] Concurrency group cancels push-triggered run when pull_request arrives
- [x] Renovate branch pushes no longer trigger incrementer, labeler, qodana
- [x] J&J ampersand warning eliminated from local and CI PDF builds